### PR TITLE
Add static support and privacy policy site for App Store submission

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,11 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "support-site",
+      "runtimeExecutable": "python3",
+      "runtimeArgs": ["-m", "http.server", "8931", "--directory", "docs"],
+      "port": 8931
+    }
+  ]
+}

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,191 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Support — Copilot Digital Logbook</title>
+<meta name="description" content="Support, FAQ, troubleshooting, bug reports, and feature requests for Copilot Digital Logbook, the FAA pilot logbook app for iPhone.">
+<link rel="stylesheet" href="styles.css">
+</head>
+<body>
+
+<header class="site">
+    <div class="header-inner">
+        <div class="logo" aria-hidden="true">&#9992;&#65039;</div>
+        <div>
+            <div class="site-title">Copilot Digital Logbook</div>
+            <div class="site-sub">Support</div>
+        </div>
+        <nav class="site-nav">
+            <a href="index.html" aria-current="page">Support</a>
+            <a href="privacy.html">Privacy Policy</a>
+        </nav>
+    </div>
+</header>
+
+<main>
+    <h1>Support</h1>
+    <p class="lede">Help with Copilot Digital Logbook, the FAA pilot logbook for iPhone.</p>
+
+    <section class="card" id="contact">
+        <h2>Contact</h2>
+        <p>The fastest way to reach us is by email. We aim to reply within 2&ndash;3 business days.</p>
+        <div class="contact-box">
+            &#9993;&#65039; <a href="mailto:copilot.logbook.support@gmail.com">copilot.logbook.support@gmail.com</a>
+        </div>
+    </section>
+
+    <section class="card" id="faq">
+        <h2>Frequently Asked Questions</h2>
+
+        <details>
+            <summary>Do I need to create an account?</summary>
+            <p>No. Copilot Digital Logbook has no accounts and no sign-up. Your logbook is stored on
+            your device and, if you are signed into iCloud, synced through your own private iCloud
+            storage.</p>
+        </details>
+
+        <details>
+            <summary>How does iCloud sync work?</summary>
+            <p>When your iPhone is signed into iCloud, every flight you log is automatically saved to
+            your personal iCloud database and appears on your other devices signed into the same
+            Apple&nbsp;ID. No setup is needed &mdash; it happens in the background.</p>
+        </details>
+
+        <details>
+            <summary>Does the app work offline?</summary>
+            <p>Yes. Everything works without a connection &mdash; logging flights, reports, and exports.
+            iCloud sync simply catches up the next time you're online.</p>
+        </details>
+
+        <details>
+            <summary>How do I export my logbook?</summary>
+            <p>Open the <strong>Reports</strong> tab and tap <strong>Export CSV</strong>. You can save the
+            file to Files, AirDrop it, or share it to any app. The CSV columns follow the standard
+            paper-logbook layout, so it imports cleanly into spreadsheets and other logbook software.</p>
+        </details>
+
+        <details>
+            <summary>Is a digital logbook acceptable to the FAA?</summary>
+            <p>Yes. 14&nbsp;CFR&nbsp;61.51 does not require a paper logbook &mdash; it requires that
+            required entries be recorded in a &ldquo;reliable record.&rdquo; Copilot records every field
+            61.51 calls for, including flight time by category, landings, and instrument time. That
+            said, always keep backups of records you rely on for a checkride or rating.</p>
+        </details>
+
+        <details>
+            <summary>What are saved aircraft profiles?</summary>
+            <p>Under <strong>Profile &rarr; My Aircraft</strong>, you can save aircraft you fly often
+            (registration, type, category, and class). The New Flight form can then fill in those
+            fields with one tap instead of retyping them.</p>
+        </details>
+
+        <details>
+            <summary>Why did the Cross Country box check itself?</summary>
+            <p>When both airport identifiers are recognized and the route is 50&nbsp;NM or more, the app
+            checks Cross Country automatically per 14&nbsp;CFR&nbsp;61.1. You can always uncheck it or
+            adjust the cross-country time.</p>
+        </details>
+
+        <details>
+            <summary>How do I log NVG time?</summary>
+            <p>Turn on <strong>NVG logging</strong> in <strong>Profile &rarr; Settings</strong>. An NVG
+            checkbox and time column then appear in the flight form.</p>
+        </details>
+    </section>
+
+    <section class="card" id="troubleshooting">
+        <h2>Troubleshooting</h2>
+
+        <details>
+            <summary>Flights aren't syncing between my devices</summary>
+            <ol>
+                <li>Confirm both devices are signed into the <strong>same Apple&nbsp;ID</strong>
+                    (Settings &rarr; your name).</li>
+                <li>Check that iCloud is enabled for the app: Settings &rarr; your name &rarr; iCloud
+                    &rarr; Saved to iCloud &rarr; make sure <strong>Copilot Digital Logbook</strong> is on.</li>
+                <li>Make sure both devices are online. Large first syncs can take a few minutes.</li>
+                <li>Open the app's <strong>Profile</strong> tab &mdash; it shows your current iCloud
+                    status. If it says &ldquo;Not signed into iCloud,&rdquo; sync is paused until you
+                    sign in.</li>
+            </ol>
+        </details>
+
+        <details>
+            <summary>The Profile tab says "Not signed into iCloud"</summary>
+            <p>Your logbook is still safe on the device &mdash; it just isn't syncing. Sign into iCloud
+            in the iOS Settings app, then reopen Copilot. New and existing entries upload
+            automatically.</p>
+        </details>
+
+        <details>
+            <summary>My data is missing after reinstalling the app</summary>
+            <p>If you were signed into iCloud when you used the app before, your logbook restores
+            automatically a few moments after the first launch &mdash; keep the app open and online. If
+            you were <em>not</em> signed into iCloud, data lived only on the device and was removed with
+            the app; restore it from a device backup if you have one.</p>
+        </details>
+
+        <details>
+            <summary>CSV export won't save to Files</summary>
+            <p>Update to the latest version of the app &mdash; this was a known issue in early builds.
+            If it persists, try sharing to a different destination (e.g. Mail or AirDrop) and let us
+            know via a bug report.</p>
+        </details>
+
+        <details>
+            <summary>An airport shows "not found — check the identifier"</summary>
+            <p>The app checks identifiers against a database of public airports to compute route
+            distance. Private strips, heliports, or international fields may not be listed &mdash; the
+            warning is only advisory, and you can log the flight anyway. Cross-country auto-detection
+            just won't compute a distance for that route.</p>
+        </details>
+
+        <details>
+            <summary>Something looks wrong or the app misbehaves</summary>
+            <ol>
+                <li>Close the app fully (swipe up from the app switcher) and reopen it.</li>
+                <li>Check the App&nbsp;Store for an update.</li>
+                <li>Restart the device.</li>
+                <li>Still stuck? Send us a bug report &mdash; see below.</li>
+            </ol>
+        </details>
+    </section>
+
+    <section class="card" id="bugs">
+        <h2>Reporting a Bug</h2>
+        <p>Email <a href="mailto:copilot.logbook.support@gmail.com?subject=Bug%20Report">copilot.logbook.support@gmail.com</a>
+        with the subject line <code>Bug Report</code> and include:</p>
+        <ul>
+            <li><strong>What happened</strong>, and what you expected to happen instead.</li>
+            <li><strong>Steps to reproduce</strong> &mdash; the taps that lead to the problem.</li>
+            <li><strong>Device and iOS version</strong> (e.g. iPhone 16 Pro, iOS 26.1 &mdash; Settings &rarr; General &rarr; About).</li>
+            <li><strong>App version</strong> (shown on the App&nbsp;Store page under &ldquo;What's New&rdquo;).</li>
+            <li><strong>Screenshots or a screen recording</strong>, if possible.</li>
+        </ul>
+        <p class="note">Please don't include your logbook data unless we ask for it &mdash; a description
+        of the entry (e.g. &ldquo;a 2.0&nbsp;hr night flight with 3 landings&rdquo;) is usually enough.</p>
+    </section>
+
+    <section class="card" id="features">
+        <h2>Feature Requests</h2>
+        <p>We build Copilot for working pilots, and most improvements start as a pilot's suggestion.
+        Email <a href="mailto:copilot.logbook.support@gmail.com?subject=Feature%20Request">copilot.logbook.support@gmail.com</a>
+        with the subject line <code>Feature Request</code> and tell us:</p>
+        <ul>
+            <li>What you're trying to do (the goal, not just the button you want).</li>
+            <li>How you handle it today &mdash; paper logbook, spreadsheet, another app.</li>
+            <li>How often it comes up in your flying.</li>
+        </ul>
+        <p>We read every request. We can't promise every feature, but real use cases directly shape
+        the roadmap.</p>
+    </section>
+</main>
+
+<footer class="site">
+    <p>Copilot Digital Logbook &middot; <a href="privacy.html">Privacy Policy</a> &middot;
+    <a href="mailto:copilot.logbook.support@gmail.com">copilot.logbook.support@gmail.com</a></p>
+</footer>
+
+</body>
+</html>

--- a/docs/privacy.html
+++ b/docs/privacy.html
@@ -1,0 +1,150 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Privacy Policy — Copilot Digital Logbook</title>
+<meta name="description" content="Privacy policy for Copilot Digital Logbook. Your logbook stays on your device and in your personal iCloud — we run no servers and collect nothing.">
+<link rel="stylesheet" href="styles.css">
+</head>
+<body>
+
+<header class="site">
+    <div class="header-inner">
+        <div class="logo" aria-hidden="true">&#9992;&#65039;</div>
+        <div>
+            <div class="site-title">Copilot Digital Logbook</div>
+            <div class="site-sub">Privacy Policy</div>
+        </div>
+        <nav class="site-nav">
+            <a href="index.html">Support</a>
+            <a href="privacy.html" aria-current="page">Privacy Policy</a>
+        </nav>
+    </div>
+</header>
+
+<main>
+    <h1>Privacy Policy</h1>
+    <p class="lede">Effective date: July 15, 2026</p>
+
+    <section class="card">
+        <h2>The Short Version</h2>
+        <p>Copilot Digital Logbook is built so that <strong>we never see your data</strong>. Your
+        logbook lives on your device and, if you use iCloud, in your own private iCloud storage
+        managed by Apple. The app has no accounts, no analytics, no advertising, no tracking, and no
+        servers operated by us. We cannot read, access, or sell your flight records &mdash; the
+        design makes it impossible, not just against policy.</p>
+    </section>
+
+    <section class="card" id="collected">
+        <h2>1. What Information the App Stores</h2>
+        <p>The app stores only what you type into it:</p>
+        <table>
+            <tr>
+                <th>Data</th>
+                <th>Examples</th>
+            </tr>
+            <tr>
+                <td>Flight entries</td>
+                <td>Date, aircraft type and registration, departure and arrival airports, flight
+                times (total, PIC/SIC, night, instrument, etc.), takeoffs and landings, training
+                time, and free-text remarks</td>
+            </tr>
+            <tr>
+                <td>Aircraft profiles</td>
+                <td>Registration, aircraft type, category and class, optional nickname</td>
+            </tr>
+            <tr>
+                <td>Pilot profile</td>
+                <td>Your name and FAA certificate number, both optional</td>
+            </tr>
+            <tr>
+                <td>App preferences</td>
+                <td>Settings such as whether NVG logging is enabled</td>
+            </tr>
+        </table>
+        <p>The app does <strong>not</strong> collect your location, contacts, photos, device
+        identifiers, usage analytics, crash reports, or any other information. It makes no network
+        requests other than iCloud sync handled by iOS itself.</p>
+    </section>
+
+    <section class="card" id="why">
+        <h2>2. Why It's Stored</h2>
+        <p>Solely to provide the app's features: keeping your pilot logbook, computing report totals
+        and currency (e.g. 14&nbsp;CFR&nbsp;61.57 recency), filling in saved aircraft, and producing
+        CSV exports you choose to create. Your name and certificate number, if entered, appear only
+        on your own exports and reports. Nothing is used for marketing, profiling, or any secondary
+        purpose.</p>
+    </section>
+
+    <section class="card" id="storage">
+        <h2>3. How It's Stored</h2>
+        <ul>
+            <li><strong>On your device</strong> &mdash; in the app's private database, protected by
+            iOS sandboxing and your device's encryption.</li>
+            <li><strong>In your personal iCloud</strong> (only if you're signed into iCloud) &mdash;
+            the app syncs your logbook to your <em>private</em> iCloud database via Apple's CloudKit
+            so it appears on your other devices. This storage belongs to your Apple&nbsp;ID; it is
+            encrypted in transit and at rest and governed by
+            <a href="https://www.apple.com/legal/privacy/">Apple's Privacy Policy</a>. We have no
+            ability to access it.</li>
+        </ul>
+        <p>Your data is kept for as long as you keep it &mdash; there is no server-side copy under
+        our control, so there is nothing for us to retain or expire.</p>
+    </section>
+
+    <section class="card" id="sharing">
+        <h2>4. Whether It's Shared with Third Parties</h2>
+        <p><strong>No.</strong> We do not sell, rent, share, or transmit your information to anyone.
+        There are no third-party analytics, advertising, or tracking SDKs in the app. The only
+        third party involved is <strong>Apple</strong>, acting as your iCloud storage provider when
+        you have sync enabled &mdash; and that relationship is between you and Apple under your
+        Apple&nbsp;ID.</p>
+        <p>Data leaves the app only when <em>you</em> export it &mdash; for example, saving a CSV
+        to Files or sharing it by email. Where you send an export is entirely your choice.</p>
+    </section>
+
+    <section class="card" id="deletion">
+        <h2>5. Deleting Your Data</h2>
+        <p>You are always in control of deletion, directly from the app:</p>
+        <ul>
+            <li><strong>Individual entries</strong> &mdash; swipe left on any flight in the Logbook
+            and tap Delete. Deletions sync to iCloud and your other devices automatically.</li>
+            <li><strong>Everything</strong> &mdash; delete every entry in the app, or delete the
+            app's iCloud data in iOS Settings (your name &rarr; iCloud &rarr; Manage Account Storage
+            &rarr; Copilot Digital Logbook &rarr; Delete Data), then remove the app.</li>
+        </ul>
+        <p>Because we hold no copy of your data, deletion happens immediately and doesn't require a
+        request to us &mdash; but if you need help with any of the steps above, email us and we'll
+        walk you through it.</p>
+    </section>
+
+    <section class="card" id="children">
+        <h2>6. Children's Privacy</h2>
+        <p>The app is a professional tool for pilots and is not directed at children under 13. It
+        collects no personal information from anyone, including children.</p>
+    </section>
+
+    <section class="card" id="changes">
+        <h2>7. Changes to This Policy</h2>
+        <p>If the app's data practices ever change &mdash; for example, if a future feature involves
+        a server we operate &mdash; we will update this policy and change the effective date above
+        before the feature ships.</p>
+    </section>
+
+    <section class="card" id="contact">
+        <h2>8. Contact Us</h2>
+        <p>Questions about this policy or your data:</p>
+        <div class="contact-box">
+            &#9993;&#65039; <a href="mailto:copilot.logbook.support@gmail.com">copilot.logbook.support@gmail.com</a>
+        </div>
+    </section>
+</main>
+
+<footer class="site">
+    <p>Copilot Digital Logbook &middot; <a href="index.html">Support</a> &middot;
+    <a href="mailto:copilot.logbook.support@gmail.com">copilot.logbook.support@gmail.com</a></p>
+</footer>
+
+</body>
+</html>

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -1,0 +1,153 @@
+/* Copilot Digital Logbook — support site styles.
+   Plain CSS, no build step. Light/dark via prefers-color-scheme. */
+
+:root {
+    --bg: #f5f6f8;
+    --card: #ffffff;
+    --text: #1c1c1e;
+    --muted: #6e6e73;
+    --accent: #0a66d0;
+    --accent-soft: #e8f0fb;
+    --border: #e3e4e8;
+    --warn: #b25000;
+    color-scheme: light dark;
+}
+
+@media (prefers-color-scheme: dark) {
+    :root {
+        --bg: #101114;
+        --card: #1b1c20;
+        --text: #f2f2f6;
+        --muted: #9a9aa1;
+        --accent: #5aa2f0;
+        --accent-soft: #17263a;
+        --border: #2b2c31;
+        --warn: #e8964a;
+    }
+}
+
+* { box-sizing: border-box; }
+
+body {
+    margin: 0;
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+    background: var(--bg);
+    color: var(--text);
+    line-height: 1.6;
+}
+
+header.site {
+    background: var(--card);
+    border-bottom: 1px solid var(--border);
+    padding: 1.1rem 1.25rem;
+}
+
+.header-inner {
+    max-width: 760px;
+    margin: 0 auto;
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    flex-wrap: wrap;
+}
+
+.logo {
+    width: 40px;
+    height: 40px;
+    border-radius: 9px;
+    background: var(--accent);
+    color: #fff;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 1.3rem;
+    flex: none;
+}
+
+.site-title { font-weight: 700; font-size: 1.05rem; }
+.site-sub { color: var(--muted); font-size: 0.85rem; }
+
+nav.site-nav { margin-left: auto; display: flex; gap: 1rem; }
+nav.site-nav a { color: var(--accent); text-decoration: none; font-weight: 600; font-size: 0.95rem; }
+nav.site-nav a:hover { text-decoration: underline; }
+
+main {
+    max-width: 760px;
+    margin: 0 auto;
+    padding: 1.5rem 1.25rem 3rem;
+}
+
+h1 { font-size: 1.7rem; margin: 0.5rem 0 0.25rem; }
+.lede { color: var(--muted); margin-top: 0; }
+
+section.card {
+    background: var(--card);
+    border: 1px solid var(--border);
+    border-radius: 12px;
+    padding: 1.25rem 1.4rem;
+    margin: 1.25rem 0;
+}
+
+section.card h2 {
+    margin-top: 0;
+    font-size: 1.2rem;
+}
+
+a { color: var(--accent); }
+
+.contact-box {
+    background: var(--accent-soft);
+    border-radius: 10px;
+    padding: 0.9rem 1.1rem;
+    font-size: 1.02rem;
+}
+
+details {
+    border-bottom: 1px solid var(--border);
+    padding: 0.55rem 0;
+}
+details:last-of-type { border-bottom: none; }
+
+summary {
+    cursor: pointer;
+    font-weight: 600;
+    padding: 0.2rem 0;
+}
+summary:hover { color: var(--accent); }
+details > p, details > ol, details > ul { margin: 0.5rem 0 0.35rem; color: var(--text); }
+
+ol li, ul li { margin: 0.3rem 0; }
+
+code {
+    background: var(--accent-soft);
+    border-radius: 5px;
+    padding: 0.1rem 0.35rem;
+    font-size: 0.9em;
+}
+
+table {
+    border-collapse: collapse;
+    width: 100%;
+    font-size: 0.95rem;
+}
+th, td {
+    text-align: left;
+    padding: 0.5rem 0.6rem;
+    border-bottom: 1px solid var(--border);
+    vertical-align: top;
+}
+th { color: var(--muted); font-weight: 600; }
+
+.note {
+    color: var(--muted);
+    font-size: 0.9rem;
+}
+
+footer.site {
+    max-width: 760px;
+    margin: 0 auto;
+    padding: 0 1.25rem 2.5rem;
+    color: var(--muted);
+    font-size: 0.85rem;
+}
+footer.site a { color: var(--muted); }


### PR DESCRIPTION
Two-page static site under docs/ (hostable via GitHub Pages):

- index.html: support page with contact email, FAQ, troubleshooting guide, bug reporting instructions, and feature request guidelines.
- privacy.html: privacy policy covering what the app stores, why, how it's stored (device + user's private iCloud, no developer servers), third-party sharing (none), deletion steps, and contact.

The contact address is a placeholder until a real support email exists. Also adds a .claude/launch.json config to preview the site locally.