### PR TITLE
Added instrument approach and hold counts

### DIFF
--- a/Copilot.xcodeproj/xcshareddata/xcschemes/Copilot.xcscheme
+++ b/Copilot.xcodeproj/xcshareddata/xcschemes/Copilot.xcscheme
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
    LastUpgradeVersion = "2660"
-   version = "1.7">
+   version = "1.8">
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES"

--- a/Copilot/Copilot.xcdatamodeld/Copilot.xcdatamodel/contents
+++ b/Copilot/Copilot.xcdatamodeld/Copilot.xcdatamodel/contents
@@ -11,6 +11,7 @@
     <entity name="Item" representedClassName="Item" syncable="YES" codeGenerationType="class">
         <attribute name="actualInstrumentTime" optional="YES" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES"/>
         <attribute name="aircraftClass" optional="YES" attributeType="String"/>
+        <attribute name="approachCount" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="aircraftRegistration" optional="YES" attributeType="String"/>
         <attribute name="aircraftType" optional="YES" attributeType="String"/>
         <attribute name="arrivalAirport" optional="YES" attributeType="String"/>
@@ -24,6 +25,7 @@
         <attribute name="dualReceivedTime" optional="YES" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES"/>
         <attribute name="groundTrainingGivenTime" optional="YES" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES"/>
         <attribute name="groundTrainingReceivedTime" optional="YES" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES"/>
+        <attribute name="holdCount" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="id" optional="YES" attributeType="UUID" usesScalarValueType="NO"/>
         <attribute name="nightFullStopLandings" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="nightNonFullStopLandings" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>

--- a/Copilot/Features/Logbook/FlightEntryFormView.swift
+++ b/Copilot/Features/Logbook/FlightEntryFormView.swift
@@ -314,13 +314,19 @@ struct FlightEntryFormView: View {
         }
     }
 
-    /// Actual/simulated instrument time — optional, 61.51(b)(3).
+    /// Actual/simulated instrument time — optional, 61.51(b)(3) — plus the
+    /// approach count and holding-procedures flag that feed 61.57(c)
+    /// instrument currency on the Report tab.
     private var instrumentSection: some View {
         Section {
             DisclosureGroup("Instrument", isExpanded: $showInstrument) {
                 HoursField(label: "Actual Instrument", value: $entry.actualInstrumentTime)
                 HoursField(label: "Simulated Instrument", value: $entry.simulatedInstrumentTime)
+                CountField(label: "Approaches", value: $entry.approachCount)
+                CountField(label: "Holds", value: $entry.holdCount)
             }
+        } footer: {
+            Text("Approaches and holding procedures count toward 61.57(c) instrument currency.")
         }
     }
 

--- a/Copilot/Features/Report/ReportView.swift
+++ b/Copilot/Features/Report/ReportView.swift
@@ -43,18 +43,21 @@ struct ReportView: View {
 
     // MARK: Sections
 
-    /// Passenger-carrying currency per 61.57(a)/(b) over the last 90 days.
+    /// Passenger-carrying currency per 61.57(a)/(b) over the last 90 days,
+    /// plus instrument currency per 61.57(c) over the last 6 months.
     private func currencySection(entries: [FlightEntry]) -> some View {
         let day = LogbookStats.dayCurrency(for: entries)
         let night = LogbookStats.nightCurrency(for: entries)
+        let instrument = LogbookStats.instrumentCurrency(for: entries)
 
         return Section {
             CurrencyRow(title: "Day Passengers", status: day)
             CurrencyRow(title: "Night Passengers", status: night)
+            InstrumentCurrencyRow(status: instrument)
         } header: {
-            Text("Currency (last 90 days)")
+            Text("Currency")
         } footer: {
-            Text("14 CFR 61.57 requires 3 takeoffs and 3 landings within the preceding 90 days (full-stop at night) to carry passengers.")
+            Text("14 CFR 61.57 requires 3 takeoffs and 3 landings within the preceding 90 days (full-stop at night) to carry passengers, and 6 approaches plus holding procedures within the preceding 6 months to fly in instrument conditions.")
         }
     }
 
@@ -141,6 +144,24 @@ struct CurrencyRow: View {
             Text(title)
             Spacer()
             Text("\(status.takeoffs) T/O · \(status.landings) LDG")
+                .foregroundStyle(.secondary)
+                .monospacedDigit()
+        }
+    }
+}
+
+/// Green/red instrument-currency line: approach count plus whether
+/// holding procedures were logged within the window.
+struct InstrumentCurrencyRow: View {
+    let status: InstrumentCurrencyStatus
+
+    var body: some View {
+        HStack {
+            Image(systemName: status.isCurrent ? "checkmark.circle.fill" : "xmark.circle.fill")
+                .foregroundStyle(status.isCurrent ? .green : .red)
+            Text("Instrument")
+            Spacer()
+            Text("\(status.approaches) APP · \(status.holds) HOLD")
                 .foregroundStyle(.secondary)
                 .monospacedDigit()
         }

--- a/Copilot/Models/FlightEntry.swift
+++ b/Copilot/Models/FlightEntry.swift
@@ -54,6 +54,12 @@ struct FlightEntry: Identifiable, Equatable {
     var actualInstrumentTime: Double = 0
     /// Simulated instrument time (under the hood).
     var simulatedInstrumentTime: Double = 0
+    /// Instrument approaches flown, counted toward 61.57(c) currency.
+    var approachCount: Int = 0
+    /// Holding procedures performed, counted toward the other half of the
+    /// 61.57(c) instrument currency requirement (along with intercepting
+    /// and tracking courses through electronic navigation).
+    var holdCount: Int = 0
 
     // MARK: Takeoffs and landings
     var dayTakeoffs: Int = 0
@@ -123,6 +129,8 @@ extension FlightEntry {
         nvgTime = item.nvgTime
         actualInstrumentTime = item.actualInstrumentTime
         simulatedInstrumentTime = item.simulatedInstrumentTime
+        approachCount = Int(item.approachCount)
+        holdCount = Int(item.holdCount)
         dayTakeoffs = Int(item.dayTakeoffs)
         dayFullStopLandings = Int(item.dayFullStopLandings)
         dayNonFullStopLandings = Int(item.dayNonFullStopLandings)
@@ -157,6 +165,8 @@ extension FlightEntry {
         item.nvgTime = nvgTime
         item.actualInstrumentTime = actualInstrumentTime
         item.simulatedInstrumentTime = simulatedInstrumentTime
+        item.approachCount = Int16(clamping: approachCount)
+        item.holdCount = Int16(clamping: holdCount)
         item.dayTakeoffs = Int16(clamping: dayTakeoffs)
         item.dayFullStopLandings = Int16(clamping: dayFullStopLandings)
         item.dayNonFullStopLandings = Int16(clamping: dayNonFullStopLandings)

--- a/Copilot/Models/LogbookStats.swift
+++ b/Copilot/Models/LogbookStats.swift
@@ -47,6 +47,19 @@ struct CurrencyStatus {
     var isCurrent: Bool { takeoffs >= 3 && landings >= 3 }
 }
 
+/// Result of a 14 CFR 61.57(c) instrument currency check.
+struct InstrumentCurrencyStatus {
+    /// Instrument approaches logged within the preceding 6 calendar months.
+    var approaches: Int
+    /// Holding procedures logged within the same window.
+    var holds: Int
+
+    /// True when both parts of 61.57(c) are satisfied: 6 approaches, plus
+    /// at least one holding procedure (and course tracking), within the
+    /// preceding 6 months.
+    var isCurrent: Bool { approaches >= 6 && holds >= 1 }
+}
+
 /// Total time flown in one category (and class, when logged).
 struct CategoryClassTotal: Identifiable {
     let category: AircraftCategory
@@ -134,8 +147,25 @@ enum LogbookStats {
         )
     }
 
-    /// The start of the preceding-90-day window used by 61.57.
+    /// Instrument currency per 61.57(c): 6 instrument approaches, holding
+    /// procedures, and intercepting/tracking courses, all within the
+    /// preceding 6 calendar months.
+    static func instrumentCurrency(for entries: [FlightEntry], asOf now: Date = Date()) -> InstrumentCurrencyStatus {
+        let start = instrumentWindowStart(from: now)
+        let recent = entries.filter { $0.date >= start }
+        return InstrumentCurrencyStatus(
+            approaches: recent.reduce(0) { $0 + $1.approachCount },
+            holds: recent.reduce(0) { $0 + $1.holdCount }
+        )
+    }
+
+    /// The start of the preceding-90-day window used by 61.57(a)/(b).
     private static func windowStart(from now: Date) -> Date {
         Calendar.current.date(byAdding: .day, value: -90, to: now) ?? now
+    }
+
+    /// The start of the preceding-6-month window used by 61.57(c).
+    private static func instrumentWindowStart(from now: Date) -> Date {
+        Calendar.current.date(byAdding: .month, value: -6, to: now) ?? now
     }
 }

--- a/CopilotTests/CopilotTests.swift
+++ b/CopilotTests/CopilotTests.swift
@@ -18,6 +18,8 @@ private func makeEntry(
     dayFullStopLandings: Int = 0,
     nightTakeoffs: Int = 0,
     nightFullStopLandings: Int = 0,
+    approachCount: Int = 0,
+    holdCount: Int = 0,
     notes: String = ""
 ) -> FlightEntry {
     var entry = FlightEntry()
@@ -31,6 +33,8 @@ private func makeEntry(
     entry.dayFullStopLandings = dayFullStopLandings
     entry.nightTakeoffs = nightTakeoffs
     entry.nightFullStopLandings = nightFullStopLandings
+    entry.approachCount = approachCount
+    entry.holdCount = holdCount
     entry.notes = notes
     return entry
 }
@@ -88,6 +92,36 @@ struct LogbookStatsTests {
         ]
         let status = LogbookStats.dayCurrency(for: entries)
         #expect(status.takeoffs == 0)
+        #expect(!status.isCurrent)
+    }
+
+    @Test func instrumentCurrencyRequiresApproachesAndHolds() {
+        let entries = [
+            makeEntry(daysAgo: 30, approachCount: 4, holdCount: 1),
+            makeEntry(daysAgo: 60, approachCount: 2),
+        ]
+        let status = LogbookStats.instrumentCurrency(for: entries)
+        #expect(status.approaches == 6)
+        #expect(status.holds == 1)
+        #expect(status.isCurrent)
+    }
+
+    @Test func instrumentCurrencyFailsWithoutHolds() {
+        // 6 approaches but no holding procedures logged.
+        let entries = [makeEntry(daysAgo: 10, approachCount: 6)]
+        let status = LogbookStats.instrumentCurrency(for: entries)
+        #expect(status.approaches == 6)
+        #expect(status.holds == 0)
+        #expect(!status.isCurrent)
+    }
+
+    @Test func instrumentCurrencyExcludesFlightsOlderThan6Months() {
+        let entries = [
+            makeEntry(daysAgo: 200, approachCount: 6, holdCount: 2),
+        ]
+        let status = LogbookStats.instrumentCurrency(for: entries)
+        #expect(status.approaches == 0)
+        #expect(status.holds == 0)
         #expect(!status.isCurrent)
     }
 


### PR DESCRIPTION
## Add 61.57(c) instrument currency tracking

### Summary
Adds instrument currency tracking to the Report tab, alongside the existing day/night passenger-carrying currency checks. Pilots can now log instrument approaches and holding procedures per flight, and see at a glance whether they meet 14 CFR 61.57(c) — 6 instrument approaches plus holding procedures within the preceding 6 calendar months.

### Changes
- **`Copilot.xcdatamodel`** — adds `approachCount` and `holdCount` (both `Integer 16`, default `0`) to the `Item` entity
- **`FlightEntry`** — mirrors the two new fields and wires them into the Core Data read/write mapping
- **`LogbookStats`** — new `InstrumentCurrencyStatus` struct and `instrumentCurrency(for:asOf:)`, filtering entries to the preceding 6 months and requiring `approaches >= 6 && holds >= 1` to be current
- **`FlightEntryFormView`** — two new steppers ("Approaches" and "Holds") under the existing Instrument disclosure group
- **`ReportView`** — new currency row showing approach/hold counts and a green/red status indicator, next to the existing day/night rows
- **`CopilotTests`** — coverage for the 6-month windowing and the approach/hold thresholds

### Not included
Certificate/medical expiration tracking (61.56 flight review, medical currency) was explored in an earlier iteration of this branch but has been removed — out of scope for this PR.

### Testing
Unit tests added for `LogbookStats.instrumentCurrency`, covering: entries within the window meeting both thresholds, entries missing the hold requirement, and entries outside the 6-month window being excluded. No UI tests added — currency row rendering was verified by reading through `ReportView`, not by running the simulator.