### PR TITLE
Port instrument approach/hold counts to Android; export them in CSV on both platforms

### DIFF
--- a/Copilot.xcodeproj/project.pbxproj
+++ b/Copilot.xcodeproj/project.pbxproj
@@ -305,6 +305,7 @@
 				);
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.boreflight.Copilot;
+				PRODUCT_MODULE_NAME = Copilot;
 				PRODUCT_NAME = "Copilot Digital Logbook";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
@@ -335,6 +336,7 @@
 				);
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.boreflight.Copilot;
+				PRODUCT_MODULE_NAME = Copilot;
 				PRODUCT_NAME = "Copilot Digital Logbook";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
@@ -480,7 +482,7 @@
 				SWIFT_EMIT_LOC_STRINGS = NO;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
-				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Copilot.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Copilot";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Copilot Digital Logbook.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Copilot Digital Logbook";
 			};
 			name = Debug;
 		};
@@ -499,7 +501,7 @@
 				SWIFT_EMIT_LOC_STRINGS = NO;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
-				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Copilot.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Copilot";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Copilot Digital Logbook.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Copilot Digital Logbook";
 			};
 			name = Release;
 		};

--- a/Copilot/Models/CSVExporter.swift
+++ b/Copilot/Models/CSVExporter.swift
@@ -14,7 +14,7 @@ enum CSVExporter {
     static let headers = [
         "Date", "Aircraft Type", "Category", "Class", "Registration", "From", "To",
         "Total Time", "PIC", "SIC", "Solo", "Cross Country", "Night", "NVG",
-        "Actual Instrument", "Simulated Instrument",
+        "Actual Instrument", "Simulated Instrument", "Approaches", "Holds",
         "Day Takeoffs", "Day Full-Stop Landings", "Day Non-Full-Stop Landings",
         "Night Takeoffs", "Night Full-Stop Landings", "Night Non-Full-Stop Landings",
         "Dual Given", "Dual Received", "Simulator",
@@ -39,6 +39,7 @@ enum CSVExporter {
                 hours(e.totalTime), hours(e.picTime), hours(e.sicTime),
                 hours(e.soloTime), hours(e.xcTime), hours(e.nightTime), hours(e.nvgTime),
                 hours(e.actualInstrumentTime), hours(e.simulatedInstrumentTime),
+                String(e.approachCount), String(e.holdCount),
                 String(e.dayTakeoffs), String(e.dayFullStopLandings), String(e.dayNonFullStopLandings),
                 String(e.nightTakeoffs), String(e.nightFullStopLandings), String(e.nightNonFullStopLandings),
                 hours(e.dualGivenTime), hours(e.dualReceivedTime), hours(e.simulatorTime),

--- a/CopilotTests/CopilotTests.swift
+++ b/CopilotTests/CopilotTests.swift
@@ -192,6 +192,13 @@ struct CSVExporterTests {
         #expect(csv.split(separator: "\n")[1].contains("2.0"))
     }
 
+    @Test func csvIncludesApproachAndHoldColumns() {
+        let entry = makeEntry(approachCount: 3, holdCount: 1)
+        let csv = CSVExporter.csv(for: [entry])
+        #expect(csv.contains("Approaches,Holds"))
+        #expect(csv.split(separator: "\n")[1].contains("0.0,3,1,0"))
+    }
+
     @Test func entryValidationRequiresCoreFields() {
         #expect(makeEntry().isValid)
 

--- a/android/app/src/main/java/com/vincentwang/copilot/data/CopilotDatabase.kt
+++ b/android/app/src/main/java/com/vincentwang/copilot/data/CopilotDatabase.kt
@@ -10,7 +10,7 @@ import androidx.sqlite.db.SupportSQLiteDatabase
 // Room counterpart of PersistenceController (Core Data + CloudKit on iOS).
 @Database(
     entities = [Item::class, AircraftProfile::class],
-    version = 2,
+    version = 3,
     exportSchema = false
 )
 abstract class CopilotDatabase : RoomDatabase() {
@@ -40,6 +40,19 @@ abstract class CopilotDatabase : RoomDatabase() {
             }
         }
 
+        /** v2 → v3: instrument approach and hold counts for 61.57(c)
+         *  instrument currency. */
+        private val MIGRATION_2_3 = object : Migration(2, 3) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL(
+                    "ALTER TABLE items ADD COLUMN approachCount INTEGER NOT NULL DEFAULT 0"
+                )
+                db.execSQL(
+                    "ALTER TABLE items ADD COLUMN holdCount INTEGER NOT NULL DEFAULT 0"
+                )
+            }
+        }
+
         @Volatile
         private var instance: CopilotDatabase? = null
 
@@ -49,7 +62,7 @@ abstract class CopilotDatabase : RoomDatabase() {
                     context.applicationContext,
                     CopilotDatabase::class.java,
                     "copilot.db"
-                ).addMigrations(MIGRATION_1_2).build().also { instance = it }
+                ).addMigrations(MIGRATION_1_2, MIGRATION_2_3).build().also { instance = it }
             }
     }
 }

--- a/android/app/src/main/java/com/vincentwang/copilot/data/Item.kt
+++ b/android/app/src/main/java/com/vincentwang/copilot/data/Item.kt
@@ -26,6 +26,10 @@ data class Item(
     val xcTime: Double = 0.0,
     val actualInstrumentTime: Double = 0.0,
     val simulatedInstrumentTime: Double = 0.0,
+    @ColumnInfo(defaultValue = "0")
+    val approachCount: Int = 0,
+    @ColumnInfo(defaultValue = "0")
+    val holdCount: Int = 0,
     val simulatorTime: Double = 0.0,
     val nvgTime: Double = 0.0,
     val dualGivenTime: Double = 0.0,
@@ -59,6 +63,8 @@ data class Item(
         "xcTime" to xcTime,
         "actualInstrumentTime" to actualInstrumentTime,
         "simulatedInstrumentTime" to simulatedInstrumentTime,
+        "approachCount" to approachCount,
+        "holdCount" to holdCount,
         "simulatorTime" to simulatorTime,
         "nvgTime" to nvgTime,
         "dualGivenTime" to dualGivenTime,
@@ -96,6 +102,8 @@ data class Item(
                 xcTime = double("xcTime"),
                 actualInstrumentTime = double("actualInstrumentTime"),
                 simulatedInstrumentTime = double("simulatedInstrumentTime"),
+                approachCount = int("approachCount"),
+                holdCount = int("holdCount"),
                 simulatorTime = double("simulatorTime"),
                 nvgTime = double("nvgTime"),
                 dualGivenTime = double("dualGivenTime"),

--- a/android/app/src/main/java/com/vincentwang/copilot/features/logbook/FlightEntryFormSheet.kt
+++ b/android/app/src/main/java/com/vincentwang/copilot/features/logbook/FlightEntryFormSheet.kt
@@ -402,8 +402,12 @@ fun FlightEntryFormSheet(
                 }
             }
 
-            // MARK: Instrument (61.51(b)(3)).
-            FormSection {
+            // MARK: Instrument (61.51(b)(3)), plus the approach and hold
+            // counts that feed 61.57(c) instrument currency on the Report tab.
+            FormSection(
+                footer = "Approaches and holding procedures count toward " +
+                    "61.57(c) instrument currency."
+            ) {
                 DisclosureGroup(
                     "Instrument",
                     expanded = showInstrument,
@@ -414,6 +418,12 @@ fun FlightEntryFormSheet(
                     }
                     HoursField("Simulated Instrument", entry.simulatedInstrumentTime) {
                         entry = entry.copy(simulatedInstrumentTime = it)
+                    }
+                    CountField("Approaches", entry.approachCount) {
+                        entry = entry.copy(approachCount = it)
+                    }
+                    CountField("Holds", entry.holdCount) {
+                        entry = entry.copy(holdCount = it)
                     }
                 }
             }

--- a/android/app/src/main/java/com/vincentwang/copilot/features/report/ReportScreen.kt
+++ b/android/app/src/main/java/com/vincentwang/copilot/features/report/ReportScreen.kt
@@ -44,6 +44,7 @@ import com.vincentwang.copilot.ui.components.CurrencyRow
 import com.vincentwang.copilot.ui.components.FormRow
 import com.vincentwang.copilot.ui.components.FormSection
 import com.vincentwang.copilot.ui.components.HoursRow
+import com.vincentwang.copilot.ui.components.InstrumentCurrencyRow
 
 /**
  * Career totals, FAR 61.57 currency, per-aircraft breakdown, and CSV
@@ -68,6 +69,7 @@ fun ReportScreen(model: LogbookViewModel = viewModel()) {
     val totals = LogbookStats.totals(entries)
     val day = LogbookStats.dayCurrency(entries)
     val night = LogbookStats.nightCurrency(entries)
+    val instrument = LogbookStats.instrumentCurrency(entries)
     val categoryTotals = LogbookStats.categoryTotals(entries)
 
     Scaffold(
@@ -79,14 +81,18 @@ fun ReportScreen(model: LogbookViewModel = viewModel()) {
                 .padding(padding)
                 .verticalScroll(rememberScrollState())
         ) {
-            // Passenger-carrying currency per 61.57(a)/(b) over the last 90 days.
+            // Passenger-carrying currency per 61.57(a)/(b) over the last 90 days,
+            // plus instrument currency per 61.57(c) over the last 6 months.
             FormSection(
-                title = "Currency (last 90 days)",
+                title = "Currency",
                 footer = "14 CFR 61.57 requires 3 takeoffs and 3 landings within the " +
-                    "preceding 90 days (full-stop at night) to carry passengers."
+                    "preceding 90 days (full-stop at night) to carry passengers, and " +
+                    "6 approaches plus holding procedures within the preceding " +
+                    "6 months to fly in instrument conditions."
             ) {
                 CurrencyRow("Day Passengers", day)
                 CurrencyRow("Night Passengers", night)
+                InstrumentCurrencyRow(instrument)
             }
 
             // Career flight-time totals.

--- a/android/app/src/main/java/com/vincentwang/copilot/models/CsvExporter.kt
+++ b/android/app/src/main/java/com/vincentwang/copilot/models/CsvExporter.kt
@@ -15,7 +15,7 @@ object CsvExporter {
     val headers = listOf(
         "Date", "Aircraft Type", "Category", "Class", "Registration", "From", "To",
         "Total Time", "PIC", "SIC", "Solo", "Cross Country", "Night", "NVG",
-        "Actual Instrument", "Simulated Instrument",
+        "Actual Instrument", "Simulated Instrument", "Approaches", "Holds",
         "Day Takeoffs", "Day Full-Stop Landings", "Day Non-Full-Stop Landings",
         "Night Takeoffs", "Night Full-Stop Landings", "Night Non-Full-Stop Landings",
         "Dual Given", "Dual Received", "Simulator",
@@ -39,6 +39,7 @@ object CsvExporter {
                 hours(e.totalTime), hours(e.picTime), hours(e.sicTime),
                 hours(e.soloTime), hours(e.xcTime), hours(e.nightTime), hours(e.nvgTime),
                 hours(e.actualInstrumentTime), hours(e.simulatedInstrumentTime),
+                e.approachCount.toString(), e.holdCount.toString(),
                 e.dayTakeoffs.toString(), e.dayFullStopLandings.toString(),
                 e.dayNonFullStopLandings.toString(),
                 e.nightTakeoffs.toString(), e.nightFullStopLandings.toString(),

--- a/android/app/src/main/java/com/vincentwang/copilot/models/FlightEntry.kt
+++ b/android/app/src/main/java/com/vincentwang/copilot/models/FlightEntry.kt
@@ -46,6 +46,12 @@ data class FlightEntry(
     // Instrument conditions (61.51(b)(3))
     val actualInstrumentTime: Double = 0.0,
     val simulatedInstrumentTime: Double = 0.0,
+    /** Instrument approaches flown, counted toward 61.57(c) currency. */
+    val approachCount: Int = 0,
+    /** Holding procedures performed, counted toward the other half of the
+     *  61.57(c) instrument currency requirement (along with intercepting
+     *  and tracking courses through electronic navigation). */
+    val holdCount: Int = 0,
 
     // Takeoffs and landings
     val dayTakeoffs: Int = 0,
@@ -102,6 +108,8 @@ data class FlightEntry(
         nvgTime = nvgTime,
         actualInstrumentTime = actualInstrumentTime,
         simulatedInstrumentTime = simulatedInstrumentTime,
+        approachCount = approachCount,
+        holdCount = holdCount,
         dayTakeoffs = dayTakeoffs,
         dayFullStopLandings = dayFullStopLandings,
         dayNonFullStopLandings = dayNonFullStopLandings,
@@ -138,6 +146,8 @@ data class FlightEntry(
             nvgTime = item.nvgTime,
             actualInstrumentTime = item.actualInstrumentTime,
             simulatedInstrumentTime = item.simulatedInstrumentTime,
+            approachCount = item.approachCount,
+            holdCount = item.holdCount,
             dayTakeoffs = item.dayTakeoffs,
             dayFullStopLandings = item.dayFullStopLandings,
             dayNonFullStopLandings = item.dayNonFullStopLandings,

--- a/android/app/src/main/java/com/vincentwang/copilot/models/LogbookStats.kt
+++ b/android/app/src/main/java/com/vincentwang/copilot/models/LogbookStats.kt
@@ -43,6 +43,19 @@ data class CurrencyStatus(
     val isCurrent: Boolean get() = takeoffs >= 3 && landings >= 3
 }
 
+/** Result of a 14 CFR 61.57(c) instrument currency check. */
+data class InstrumentCurrencyStatus(
+    /** Instrument approaches logged within the preceding 6 calendar months. */
+    val approaches: Int,
+    /** Holding procedures logged within the same window. */
+    val holds: Int
+) {
+    /** True when both parts of 61.57(c) are satisfied: 6 approaches, plus
+     *  at least one holding procedure (and course tracking), within the
+     *  preceding 6 months. */
+    val isCurrent: Boolean get() = approaches >= 6 && holds >= 1
+}
+
 /** Total time flown in one category (and class, when logged). */
 data class CategoryClassTotal(
     val category: AircraftCategory,
@@ -125,6 +138,23 @@ object LogbookStats {
         )
     }
 
-    /** The start of the preceding-90-day window used by 61.57. */
+    /** Instrument currency per 61.57(c): 6 instrument approaches, holding
+     *  procedures, and intercepting/tracking courses, all within the
+     *  preceding 6 calendar months. */
+    fun instrumentCurrency(
+        entries: List<FlightEntry>,
+        asOf: LocalDate = LocalDate.now()
+    ): InstrumentCurrencyStatus {
+        val recent = entries.filter { it.date >= instrumentWindowStart(asOf) }
+        return InstrumentCurrencyStatus(
+            approaches = recent.sumOf { it.approachCount },
+            holds = recent.sumOf { it.holdCount }
+        )
+    }
+
+    /** The start of the preceding-90-day window used by 61.57(a)/(b). */
     private fun windowStart(asOf: LocalDate): LocalDate = asOf.minusDays(90)
+
+    /** The start of the preceding-6-month window used by 61.57(c). */
+    private fun instrumentWindowStart(asOf: LocalDate): LocalDate = asOf.minusMonths(6)
 }

--- a/android/app/src/main/java/com/vincentwang/copilot/ui/components/FlightRow.kt
+++ b/android/app/src/main/java/com/vincentwang/copilot/ui/components/FlightRow.kt
@@ -19,6 +19,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.vincentwang.copilot.models.CurrencyStatus
 import com.vincentwang.copilot.models.FlightEntry
+import com.vincentwang.copilot.models.InstrumentCurrencyStatus
 import java.time.format.DateTimeFormatter
 import java.util.Locale
 
@@ -79,6 +80,29 @@ fun CurrencyRow(title: String, status: CurrencyStatus) {
             Text(title, modifier = Modifier.weight(1f).padding(start = 8.dp))
             Text(
                 "${status.takeoffs} T/O · ${status.landings} LDG",
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                fontFamily = FontFamily.Monospace,
+                style = MaterialTheme.typography.bodyMedium
+            )
+        }
+    }
+}
+
+/** Green/red instrument-currency line: approach count plus whether
+ *  holding procedures were logged within the window
+ *  (InstrumentCurrencyRow on iOS). */
+@Composable
+fun InstrumentCurrencyRow(status: InstrumentCurrencyStatus) {
+    FormRow {
+        Row(modifier = Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically) {
+            Icon(
+                if (status.isCurrent) Icons.Filled.CheckCircle else Icons.Filled.Cancel,
+                contentDescription = if (status.isCurrent) "Current" else "Not current",
+                tint = if (status.isCurrent) Color(0xFF34A853) else MaterialTheme.colorScheme.error
+            )
+            Text("Instrument", modifier = Modifier.weight(1f).padding(start = 8.dp))
+            Text(
+                "${status.approaches} APP · ${status.holds} HOLD",
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
                 fontFamily = FontFamily.Monospace,
                 style = MaterialTheme.typography.bodyMedium

--- a/android/app/src/test/java/com/vincentwang/copilot/LogbookTests.kt
+++ b/android/app/src/test/java/com/vincentwang/copilot/LogbookTests.kt
@@ -31,6 +31,8 @@ private fun makeEntry(
     dayFullStopLandings: Int = 0,
     nightTakeoffs: Int = 0,
     nightFullStopLandings: Int = 0,
+    approachCount: Int = 0,
+    holdCount: Int = 0,
     notes: String = ""
 ) = FlightEntry(
     date = LocalDate.now().minusDays(daysAgo),
@@ -43,6 +45,8 @@ private fun makeEntry(
     dayFullStopLandings = dayFullStopLandings,
     nightTakeoffs = nightTakeoffs,
     nightFullStopLandings = nightFullStopLandings,
+    approachCount = approachCount,
+    holdCount = holdCount,
     notes = notes
 )
 
@@ -105,6 +109,39 @@ class LogbookStatsTests {
         )
         val status = LogbookStats.dayCurrency(entries)
         assertEquals(0, status.takeoffs)
+        assertFalse(status.isCurrent)
+    }
+
+    @Test
+    fun instrumentCurrencyRequiresApproachesAndHolds() {
+        val entries = listOf(
+            makeEntry(daysAgo = 30, approachCount = 4, holdCount = 1),
+            makeEntry(daysAgo = 60, approachCount = 2)
+        )
+        val status = LogbookStats.instrumentCurrency(entries)
+        assertEquals(6, status.approaches)
+        assertEquals(1, status.holds)
+        assertTrue(status.isCurrent)
+    }
+
+    @Test
+    fun instrumentCurrencyFailsWithoutHolds() {
+        // 6 approaches but no holding procedures logged.
+        val entries = listOf(makeEntry(daysAgo = 10, approachCount = 6))
+        val status = LogbookStats.instrumentCurrency(entries)
+        assertEquals(6, status.approaches)
+        assertEquals(0, status.holds)
+        assertFalse(status.isCurrent)
+    }
+
+    @Test
+    fun instrumentCurrencyExcludesFlightsOlderThan6Months() {
+        val entries = listOf(
+            makeEntry(daysAgo = 200, approachCount = 6, holdCount = 2)
+        )
+        val status = LogbookStats.instrumentCurrency(entries)
+        assertEquals(0, status.approaches)
+        assertEquals(0, status.holds)
         assertFalse(status.isCurrent)
     }
 
@@ -180,6 +217,14 @@ class CsvExporterTests {
         val csv = CsvExporter.csv(listOf(entry))
         assertTrue(csv.contains("Cross Country"))
         assertTrue(csv.trimEnd().split("\n")[1].contains("2.0"))
+    }
+
+    @Test
+    fun csvIncludesApproachAndHoldColumns() {
+        val entry = makeEntry(approachCount = 3, holdCount = 1)
+        val csv = CsvExporter.csv(listOf(entry))
+        assertTrue(csv.contains("Approaches,Holds"))
+        assertTrue(csv.trimEnd().split("\n")[1].contains("0.0,3,1,0"))
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Ports the instrument approach and hold counts feature (#10, iOS commit 213fdee) to the Android app so the platforms stay at parity: Room schema v3 with migration, `FlightEntry` fields and mappings, 61.57(c) instrument currency in `LogbookStats`, Approaches/Holds fields in the entry form's Instrument group, and an instrument currency row on the Report tab.
- Adds the logged approach/hold counts to the CSV export on **both** platforms (new "Approaches" and "Holds" columns after "Simulated Instrument"). These were logged on iOS since #10 but silently missing from the exported logbook, which pilots would need to demonstrate 61.57(c) currency.
- Repairs the iOS `CopilotTests` target, broken since the app product was renamed to "Copilot Digital Logbook": `TEST_HOST` still pointed at `Copilot.app` and the module rename broke `@testable import Copilot`. `TEST_HOST` now tracks the renamed product and `PRODUCT_MODULE_NAME` pins the module name back to `Copilot`.

## Testing
- Android: `./gradlew :app:assembleDebug :app:testDebugUnitTest` — build succeeds, all unit tests pass, including the three ported instrument-currency tests and a new CSV column test.
- iOS: `xcodebuild test -scheme Copilot -only-testing:CopilotTests` on the iPhone 16 simulator — **TEST SUCCEEDED**, including the three instrument-currency tests from #10 (previously un-runnable due to the broken test host) and the new CSV column test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)